### PR TITLE
Improve PR description template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -16,7 +16,15 @@ If your PR is under active development, please submit it as a "draft". Once it's
 #### What changes are made to solve it?
 
 ## References
-<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
+<!--
+Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.
+
+When referencing links, follow these examples:
+* closes https://github.com/openfga/{repo}/issues/{issue_number}
+* reverts https://github.com/openfga/{repo}/pull/{pr_number}
+* followup https://github.com/openfga/{repo}/pull/{pr_number}
+* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
+-->
 
 ## Review Checklist
 - [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -9,6 +9,11 @@ If your PR is under active development, please submit it as a "draft". Once it's
 
 ## Description
 <!-- Provide a detailed description of the changes -->
+#### What problem is being solved?
+
+#### How is it being solved?
+
+#### What changes are made to solve it?
 
 ## References
 <!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->


### PR DESCRIPTION
## Description
#### What problem is being solved?
The descriptions we have in our PRs right now do not get into the details of what is being submitted. To make the PR description clearer, we want to improve the PR description we have.

#### How is it being solved?
By making a change at the org level PR description template

#### What changes are made to solve it?
Instead of overriding at the `openfga/openfga` repository level. I am proposing a change at the organisation level template. This way we won't have a drift in case there is a change in the template at the organisation level.


## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

