### PR TITLE
chore: Add security scope and experimental features CVE policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,15 +8,15 @@ All vulnerabilities and associated information will be treated with full confide
 
 ## Scope
 
-The following are **in scope** for security coverage and CVE tracking:
+The following are **in scope** for CVE assignment:
 
 - OpenFGA server and its stable APIs
 - Official OpenFGA SDKs (stable releases)
 - OpenFGA CLI (stable releases)
 
-The following are **out of scope** for CVE coverage:
+The following are **out of scope** for CVE assignment:
 
-- **Experimental features**: Features marked as experimental are not eligible for CVE tracking. Experimental features are provided as-is, may change or be removed without notice, and do not carry the same security support guarantees as stable features.
+- **Experimental features**: Features marked as experimental are not eligible for CVE assignment. Experimental features are provided as-is, may change or be removed without notice, and do not carry the same security support guarantees as stable features.
 - **Unverified scanner output**: We do not accept reports that consist solely of automated vulnerability scanner output without confirmation that the reported issue actually affects OpenFGA.
 
 If you discover a security issue in an experimental feature, you are still welcome to report it to security@openfga.dev. We will assess the report and may address it, but it will not be assigned a CVE or treated as a formal security advisory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,3 +5,18 @@
 Please use this email: security@openfga.dev to reach out to us regarding any security concerns/vulnerabilities. Please avoid using GitHub issues/discussions for the same.
 
 All vulnerabilities and associated information will be treated with full confidentiality. We strive to reply within 5 business days.
+
+## Scope
+
+The following are **in scope** for security coverage and CVE tracking:
+
+- OpenFGA server and its stable APIs
+- Official OpenFGA SDKs (stable releases)
+- OpenFGA CLI (stable releases)
+
+The following are **out of scope** for CVE coverage:
+
+- **Experimental features**: Features marked as experimental are not eligible for CVE tracking. Experimental features are provided as-is, may change or be removed without notice, and do not carry the same security support guarantees as stable features.
+- **Unverified scanner output**: We do not accept reports that consist solely of automated vulnerability scanner output without confirmation that the reported issue actually affects OpenFGA.
+
+If you discover a security issue in an experimental feature, you are still welcome to report it to security@openfga.dev. We will assess the report and may address it, but it will not be assigned a CVE or treated as a formal security advisory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,6 +13,7 @@ The following are **in scope** for CVE assignment:
 - OpenFGA server and its stable APIs
 - Official OpenFGA SDKs (stable releases)
 - OpenFGA CLI (stable releases)
+- Official tooling (stable releases), including IDE extensions, Helm Charts, GitHub Actions, and Terraform Provider
 
 The following are **out of scope** for CVE assignment:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,4 +19,4 @@ The following are **out of scope** for CVE assignment:
 - **Experimental features**: Features marked as experimental are not eligible for CVE assignment. Experimental features are provided as-is, may change or be removed without notice, and do not carry the same security support guarantees as stable features.
 - **Unverified scanner output**: We do not accept reports that consist solely of automated vulnerability scanner output without confirmation that the reported issue actually affects OpenFGA.
 
-If you discover a security issue in an experimental feature, you are still welcome to report it to security@openfga.dev. We will assess the report and may address it, but it will not be assigned a CVE or treated as a formal security advisory.
+If you discover a security issue in an experimental feature, you are still encouraged to report it to security@openfga.dev. We will assess the report and may address it, but it will not be assigned a CVE or treated as a formal security advisory.


### PR DESCRIPTION
# Summary

- Adds a "Scope" section to SECURITY.md defining what is in and out of scope for CVE tracking
- Clarifies that experimental features are not eligible for CVE publication or tracking
- Excludes unverified vulnerability scanner output from accepted reports
- Follows patterns established by other CNCF projects (e.g., Envoy's contrib extension exclusion)

## Test plan

- [ ] Review SECURITY.md renders correctly on GitHub
- [ ] Confirm scope accurately reflects current OpenFGA stable surface area

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

